### PR TITLE
added profile picture functionality (lab 6)

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -158,7 +158,15 @@ const Index = () => {
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button variant="outline" className="gap-2">
-                      <UserIcon className="w-4 h-4" />
+                      {profile?.avatar_url ? (
+                        <img
+                          src={profile.avatar_url}
+                          alt="Profile"
+                          className="w-5 h-5 rounded-full object-cover"
+                        />
+                      ) : (
+                        <UserIcon className="w-4 h-4" />
+                      )}
                       {user.email || user.phone || "Account"}
                     </Button>
                   </DropdownMenuTrigger>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
-import { ArrowLeft, Copy, Key, Mail, User, MapPin, Save, BarChart2, Search } from "lucide-react";
+import { ArrowLeft, Camera, Copy, Key, Mail, User, MapPin, Save, BarChart2, Search } from "lucide-react";
 import { Tables } from "@/integrations/supabase/types";
 import { useArtistListenerRegions } from "@/hooks/useArtistListenerRegions";
 
@@ -23,10 +23,12 @@ const ProfilePage = () => {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [uploadingAvatar, setUploadingAvatar] = useState(false);
   const [mapboxToken, setMapboxToken] = useState<string>("");
   const [editedProfile, setEditedProfile] = useState<Partial<Profile>>({});
   const [artistNameInput, setArtistNameInput] = useState("");
   const [lookupArtistId, setLookupArtistId] = useState<string | null>(null);
+  const avatarInputRef = useRef<HTMLInputElement>(null);
 
   // Load user profile and Mapbox token on mount
   useEffect(() => {
@@ -88,6 +90,58 @@ const ProfilePage = () => {
       });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !user) return;
+
+    const MAX_SIZE_MB = 5;
+    if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+      toast({ title: "File too large", description: `Max size is ${MAX_SIZE_MB} MB`, variant: "destructive" });
+      return;
+    }
+
+    const ext = file.name.split(".").pop()?.toLowerCase();
+    if (!ext || !["jpg", "jpeg", "png", "webp", "gif"].includes(ext)) {
+      toast({ title: "Invalid file type", description: "Please upload a JPG, PNG, WebP, or GIF image", variant: "destructive" });
+      return;
+    }
+
+    setUploadingAvatar(true);
+    try {
+      const filePath = `${user.id}/avatar.${ext}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("avatars")
+        .upload(filePath, file, { upsert: true });
+
+      if (uploadError) throw uploadError;
+
+      const { data: { publicUrl } } = supabase.storage
+        .from("avatars")
+        .getPublicUrl(filePath);
+
+      // Append cache-buster so the browser reloads the new image
+      const avatarUrl = `${publicUrl}?t=${Date.now()}`;
+
+      const { error: updateError } = await supabase
+        .from("profiles")
+        .update({ avatar_url: avatarUrl })
+        .eq("id", user.id);
+
+      if (updateError) throw updateError;
+
+      setProfile((prev) => prev ? { ...prev, avatar_url: avatarUrl } : prev);
+      setEditedProfile((prev) => ({ ...prev, avatar_url: avatarUrl }));
+      toast({ title: "Success", description: "Profile picture updated" });
+    } catch (error: any) {
+      toast({ title: "Upload failed", description: error.message || "Failed to upload avatar", variant: "destructive" });
+    } finally {
+      setUploadingAvatar(false);
+      // Reset input so the same file can be re-selected if needed
+      if (avatarInputRef.current) avatarInputRef.current.value = "";
     }
   };
 
@@ -185,6 +239,52 @@ const ProfilePage = () => {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
+              {/* Avatar */}
+              <div className="flex items-center gap-4">
+                <div className="relative">
+                  <div className="w-20 h-20 rounded-full overflow-hidden bg-muted border-2 border-border flex items-center justify-center">
+                    {profile?.avatar_url ? (
+                      <img
+                        src={profile.avatar_url}
+                        alt="Profile picture"
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <User className="w-8 h-8 text-muted-foreground" />
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    disabled={uploadingAvatar}
+                    onClick={() => avatarInputRef.current?.click()}
+                    className="absolute bottom-0 right-0 bg-primary text-primary-foreground rounded-full p-1.5 hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                    aria-label="Upload profile picture"
+                  >
+                    <Camera className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">Profile Picture</p>
+                  <p className="text-xs text-muted-foreground">JPG, PNG, WebP or GIF · Max 5 MB</p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={uploadingAvatar}
+                    onClick={() => avatarInputRef.current?.click()}
+                  >
+                    {uploadingAvatar ? "Uploading..." : "Change photo"}
+                  </Button>
+                </div>
+                <input
+                  ref={avatarInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  className="hidden"
+                  onChange={handleAvatarUpload}
+                />
+              </div>
+
               {/* Email/Phone */}
               <div className="space-y-2">
                 <Label className="flex items-center gap-2">

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,1 @@
-project_id = "kaajdlhcsustvjvziwdr"
+project_id = "gblzutsvoywatulevhux"

--- a/supabase/migrations/20260409000001_avatar_storage.sql
+++ b/supabase/migrations/20260409000001_avatar_storage.sql
@@ -1,0 +1,37 @@
+-- Create storage bucket for user profile pictures
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Allow authenticated users to upload their own avatar
+CREATE POLICY "Users can upload their own avatar"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'avatars'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow authenticated users to update their own avatar
+CREATE POLICY "Users can update their own avatar"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'avatars'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow authenticated users to delete their own avatar
+CREATE POLICY "Users can delete their own avatar"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'avatars'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow public read access (bucket is public)
+CREATE POLICY "Public can read avatars"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'avatars');


### PR DESCRIPTION
## **Summary**
This PR introduces end-to-end profile picture (avatar) support, covering upload, storage, and display across the application.

## **Motivation**
Previously, user accounts had no visual identity. The only customizable fields were display name and email, leaving no way to distinguish users at a glance in social features or on the main page.

## **Changes**
### **Upload & Storage**
- Added a new avatars Supabase Storage bucket (public) with row-level security policies scoped to each user's own folder ({user_id}/avatar.*), preventing cross-user modification
- Users can upload a profile picture from the Profile Settings page. Accepted formats: JPG, PNG, WebP, GIF. Maximum file size: 5 MB
- Uploads use upsert: true, so re-uploading always replaces the previous image without accumulating stale files in storage
- A cache-busting query parameter is appended to the public URL on each upload so browsers immediately reflect the change without a hard refresh
- The resulting public URL is persisted to the avatar_url column in the profiles table

### **Profile Settings Page (/profile)**
- A circular avatar preview is shown at the top of the Account Information card, defaulting to a generic user icon when no picture has been set
- A camera icon button overlays the avatar circle for quick access; a "Change photo" button is also provided for clarity
- The upload input is hidden and triggered programmatically to keep the UI clean
- The avatar can be changed an unlimited number of times — each new upload overwrites the previous one

### **Header (Index Page)**
- The dropdown trigger in the upper-right corner of the app now renders the user's avatar (small circular thumbnail) in place of the generic user icon when a profile picture is set
- Falls back gracefully to the user icon for accounts with no avatar
- Clicking the dropdown and navigating to Profile Settings is the existing flow, unchanged

### **Social Visibility**
- Because avatar_url is now populated in the profiles table, any existing components that already reference this field (friend cards, user map markers, add-friend views, etc.) will automatically display the uploaded avatar without additional changes

### **Database / Infrastructure**
- New migration: 20260409000001_avatar_storage.sql — creates the avatars bucket and its four RLS policies (INSERT, UPDATE, DELETE scoped to owner; SELECT public)
- supabase/config.toml updated to reflect the active project ID

## **Human Verification**
The team inspected the front end to ensure that the implementation refrained from breaking any existing features. The supabase database was also inspected to ensure compliance with our safety guidelines. All inspections returned positive results.